### PR TITLE
Remove outdated Django and Django REST Framework versions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A Django-based backend application for managing quizzes, grades, and user feedba
 
 ## Tech Stack
 
-- Python 3.x
-- Django 5.1.6
-- Django REST Framework 3.15.2
+- Python 3
+- Django
+- Django REST Framework
 - PostgreSQL (production) / SQLite (development)
 - JWT Authentication
 - USOS API Integration
@@ -26,7 +26,7 @@ A Django-based backend application for managing quizzes, grades, and user feedba
 
 ## Prerequisites
 
-- Python 3.x
+- Python 3
 - pip (Python package manager)
 - PostgreSQL (for production)
 - USOS API credentials


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove specific version numbers for Django and Django REST Framework from README.
> 
>   - **README.md**:
>     - Removed specific version numbers for Django and Django REST Framework in the Tech Stack section.
>     - Updated Python version notation from `3.x` to `3` in the Tech Stack and Prerequisites sections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-testownik&utm_source=github&utm_medium=referral)<sup> for e021f490491a9bf4c1a0aff124236ddc9e948002. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->