### PR TITLE
feature: simplify get_course_type function to return course type from course_id

### DIFF
--- a/grades/views.py
+++ b/grades/views.py
@@ -69,16 +69,10 @@ def generate_course_grade(course_edition: CourseEdition, grades) -> list:
     return result
 
 
-def get_course_type(course_edition: CourseEdition) -> str:
-    default_course_type = ""
-
-    if not isinstance(course_edition.user_groups, list):
-        return default_course_type
-
-    for user_group in course_edition.user_groups:
-        return user_group.class_type.en
-
-    return default_course_type
+def get_course_type(course_edition: CourseEdition) -> str | None:
+    if not course_edition.course_id:
+        return None
+    return course_edition.course_id[-1]
 
 
 @async_api_view(["GET"])


### PR DESCRIPTION
Inne podejście do https://github.com/Solvro/backend-testownik/pull/83
Wyciąganie typu kursu bezpośrednio z course_id.
Ale tak naprawde to nawet w backendzie nie trzeba tego robić i można na froncie bo course_id i tak było zwracane

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `get_grades` to use new `get_course_type` and `generate_course_grade` functions for improved course type extraction and grade handling.
> 
>   - **Functions**:
>     - Add `get_course_type(course_edition: CourseEdition) -> str | None` to extract course type from `course_id`.
>     - Add `generate_course_grade(course_edition: CourseEdition, grades) -> list` to encapsulate grade generation logic.
>   - **Behavior**:
>     - `get_grades` now uses `get_course_type` to include `course_type` in the response.
>     - Refactor `get_grades` to use `generate_course_grade` for grade data, handling multiple user groups and grade types.
>   - **Misc**:
>     - Add logic to duplicate and swap user groups in `get_grades` for courses with multiple groups.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-testownik&utm_source=github&utm_medium=referral)<sup> for f2df73542e9086514f2907fc798c4aacf3aa368e. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->