### PR TITLE
chore: upgrade django to 6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv==1.2.1
-Django==6.0
+Django>=6.0,<6.1
 usos-api>=0.3.3
 requests==2.32.5
 djangorestframework==3.16.1


### PR DESCRIPTION
Użyłem zapisu Django>=6.0,<6.1, dzięki temu automatycznie pobierze łatki bezpieczeństwa i bugfixy (wersje 6.0.x). 
Przetestowałem ręcznie działanie programu i wszystko działa poprawnie.
W najnowszej wersji dodano lekki system kolejkowania zadań, który nie wymaga instalowania zewnętrznych kombajnów jak Celery czy Redis i można to zastosować do np. notify_quiz_shared_to_groups.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Django version in `requirements.txt` to `>=6.0,<6.1` for automatic security and bugfix updates.
> 
>   - **Dependencies**:
>     - Update Django version in `requirements.txt` to `>=6.0,<6.1` for automatic security and bugfix updates.
>   - **Misc**:
>     - Mention of a new lightweight task queuing system in Django 6.0, suitable for tasks like `notify_quiz_shared_to_groups` (not implemented in this PR).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fbackend-testownik&utm_source=github&utm_medium=referral)<sup> for 4453a549f736e586c42a168a2624d334323185e7. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->